### PR TITLE
fix required param after optional for PHP 8+; add option for CSV save to disk

### DIFF
--- a/src/ReportGenerator.php
+++ b/src/ReportGenerator.php
@@ -29,7 +29,7 @@ class ReportGenerator
 		$this->applyFlush = (bool) Config::get('report-generator.flush', true);
 	}
 
-	public function of($title, Array $meta = [], $query, Array $columns)
+	public function of($title, Array $meta, $query, Array $columns)
 	{
 		$this->headers = [
 			'title' => $title,

--- a/src/ReportMedia/CSVReport.php
+++ b/src/ReportMedia/CSVReport.php
@@ -10,13 +10,17 @@ class CSVReport extends ReportGenerator
 {
     protected $showMeta = false;
 
-    public function download($filename)
+    public function download($filename, $save = false)
     {
         if (!class_exists(Writer::class)) {
             throw new Exception('Please install league/csv to generate CSV Report!');
         }
 
-        $csv = Writer::createFromFileObject(new \SplTempFileObject());
+        if ($save) {
+            $csv = Writer::createFromPath($filename, 'w');
+        } else {
+            $csv = Writer::createFromFileObject(new \SplTempFileObject());
+        }
 
         if ($this->showMeta) {
             foreach ($this->headers['meta'] as $key => $value) {
@@ -48,7 +52,14 @@ class CSVReport extends ReportGenerator
             $ctr++;
         }
 
-        $csv->output($filename . '.csv');
+        if (!$save) {
+            $csv->output($filename . '.csv');
+        }
+    }
+
+    public function store($filename)
+    {
+        $this->download($filename, true);
     }
 
     private function formatRow($result)


### PR DESCRIPTION
Solves issue #25 and issue #60 

Make `$meta` argument required, add `store()` method for CSVReport to save file to disk